### PR TITLE
Convert flru from default to named export

### DIFF
--- a/flru.d.ts
+++ b/flru.d.ts
@@ -5,6 +5,4 @@ export interface flruCache<T = any> {
   set(key: string, value: T): void;
 }
 
-declare const flru: <T = any>(max: number) => flruCache<T>;
-
-export default flru;
+export declare function flru<T = any>(max: number): flruCache<T>;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-export default function (max) {
+export function flru(max) {
 	var num, curr, prev;
 	var limit = max || 1;
 


### PR DESCRIPTION
## Changes

This PR changes the `flru` module to use named exports instead of default exports:

- Renamed the default export function in `index.js` to "flru"
- Changed the export to a named export rather than a default export
- Updated the TypeScript type definition file to reflect these changes
- The function implementation and signature remain unchanged (still takes an optional "max" parameter with a default value of 1)

## Motivation

This change improves the module by:
- Making imports more explicit (`import { flru } from 'flru'` vs `import flru from 'flru'`)
- Potentially enabling better tree-shaking in consuming code
- Maintaining consistent function naming between the implementation and exports

This is part of our ongoing effort to standardize on named exports across our codebase.