### PR TITLE
Convert default export to named export 'flru'

### DIFF
--- a/flru.d.ts
+++ b/flru.d.ts
@@ -5,6 +5,4 @@ export interface flruCache<T = any> {
   set(key: string, value: T): void;
 }
 
-declare const flru: <T = any>(max: number) => flruCache<T>;
-
-export default flru;
+export function flru<T = any>(max: number): flruCache<T>;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-export default function (max) {
+export function flru(max) {
 	var num, curr, prev;
 	var limit = max || 1;
 


### PR DESCRIPTION
This PR converts the module's default export to a named export function called 'flru'. This change improves import clarity for consumers while maintaining the same functionality.

## Changes

- Modified `src/index.js` to export a named function 'flru' instead of a default export
- Updated TypeScript declaration file to reflect the new export pattern
- Function signature and implementation remain unchanged (still takes a single 'max' parameter)

This change allows consumers to import the library more explicitly:
```js
// Before
import flru from 'flru';

// After
import { flru } from 'flru';
```

The interface `flruCache` is preserved, ensuring backward compatibility with existing typings.