### PR TITLE
feat: add TypeScript support to project

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "scripts": {
     "build": "tsc && bundt",
+    "types": "tsc --noEmit",
     "pretest": "npm run build",
     "test": "tape test/*.js | tap-spec"
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "node": ">=6"
   },
   "scripts": {
-    "build": "bundt",
+    "build": "tsc && bundt",
     "pretest": "npm run build",
     "test": "tape test/*.js | tap-spec"
   },
@@ -34,6 +34,7 @@
   "devDependencies": {
     "bundt": "^0.4.0",
     "tap-spec": "^5.0.0",
-    "tape": "^4.9.1"
+    "tape": "^4.9.1",
+    "typescript": "^5.0.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,52 @@
+export interface flruCache<T = any> {
+	clear(isPartial?: boolean): void;
+	has(key: string): boolean;
+	get(key: string): T | undefined;
+	set(key: string, value: T): void;
+}
+
+export default function flru<T = any>(max?: number): flruCache<T> {
+	let num: number;
+	let curr: Record<string, T>;
+	let prev: Record<string, T>;
+	const limit = max || 1;
+
+	function keep(key: string, value: T): void {
+		if (++num > limit) {
+			prev = curr;
+			reset(true);
+			++num;
+		}
+		curr[key] = value;
+	}
+
+	function reset(isPartial?: boolean): void {
+		num = 0;
+		curr = Object.create(null);
+		isPartial || (prev = Object.create(null));
+	}
+
+	reset();
+
+	return {
+		clear: reset,
+		has: function (key: string): boolean {
+			return curr[key] !== void 0 || prev[key] !== void 0;
+		},
+		get: function (key: string): T | undefined {
+			let val = curr[key];
+			if (val !== void 0) return val;
+			if ((val = prev[key]) !== void 0) {
+				keep(key, val);
+				return val;
+			}
+		},
+		set: function (key: string, value: T): void {
+			if (curr[key] !== void 0) {
+				curr[key] = value;
+			} else {
+				keep(key, value);
+			}
+		}
+	};
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+	"compilerOptions": {
+		"target": "ES2015",
+		"module": "ESNext",
+		"lib": ["ES2015"],
+		"declaration": true,
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"moduleResolution": "node"
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist", "test", "bench"]
+}


### PR DESCRIPTION
## Changes

This pull request adds TypeScript support to the project while maintaining backward compatibility:

### TypeScript Implementation
- Converted the main code to TypeScript with a new `src/index.ts` file
- Added proper type definitions with an interface for the `flruCache`
- Added appropriate type annotations throughout the codebase

### Configuration & Build Process
- Added `tsconfig.json` file with standard TypeScript configuration
- Added `typescript@^5.0.0` as a development dependency
- Updated the build script to run `tsc` before `bundt`
- Added a new npm script `types` that runs TypeScript's type checking without emitting JavaScript files (`tsc --noEmit`), useful for quick type validation during development

These changes enable TypeScript users to benefit from type definitions while preserving the existing functionality for JavaScript users.

> Created by **GitHub Ace** · [View Channel](https://ace.githubnext.com/lukeed/flru/01KEWHVXBHR428KJDE0XAR50FA)