### PR TITLE
feat: add FLRU cache module with TypeScript support

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "scripts": {
     "build": "bundt",
     "pretest": "npm run build",
-    "test": "tape test/*.js | tap-spec"
+    "test": "tape test/*.js | tap-spec",
+    "types": "tsc --noEmit"
   },
   "files": [
     "*.d.ts",
@@ -34,6 +35,7 @@
   "devDependencies": {
     "bundt": "^0.4.0",
     "tap-spec": "^5.0.0",
-    "tape": "^4.9.1"
+    "tape": "^4.9.1",
+    "typescript": "^5.0.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,52 @@
+export interface flruCache<T = any> {
+	clear(isPartial?: boolean): void;
+	has(key: string): boolean;
+	get(key: string): undefined | T;
+	set(key: string, value: T): void;
+}
+
+export default function flru<T = any>(max?: number): flruCache<T> {
+	let num: number;
+	let curr: Record<string, T>;
+	let prev: Record<string, T>;
+	const limit = max || 1;
+
+	function keep(key: string, value: T): void {
+		if (++num > limit) {
+			prev = curr;
+			reset(true);
+			++num;
+		}
+		curr[key] = value;
+	}
+
+	function reset(isPartial?: boolean): void {
+		num = 0;
+		curr = Object.create(null);
+		isPartial || (prev = Object.create(null));
+	}
+
+	reset();
+
+	return {
+		clear: reset,
+		has: function (key: string): boolean {
+			return curr[key] !== void 0 || prev[key] !== void 0;
+		},
+		get: function (key: string): T | undefined {
+			let val = curr[key];
+			if (val !== void 0) return val;
+			if ((val = prev[key]) !== void 0) {
+				keep(key, val);
+				return val;
+			}
+		},
+		set: function (key: string, value: T): void {
+			if (curr[key] !== void 0) {
+				curr[key] = value;
+			} else {
+				keep(key, value);
+			}
+		}
+	};
+}


### PR DESCRIPTION
Implement a fast least-recently-used (FLRU) cache module with full TypeScript support.

**FLRU Cache Implementation:**
- Export generic `flruCache` interface with core operations: clear, has, get, and set
- Implement `flru()` factory function to create cache instances with configurable maximum size (default: 1)
- Use two-tier cache architecture with current and previous caches for efficient lookups
- Support automatic cache eviction when size limit is exceeded
- Cache entries prioritize current cache and fall back to previous cache on miss

**TypeScript Integration:**
- Add TypeScript 5.0.0 as a dev dependency
- Create new "types" npm script that runs `tsc --noEmit` for type validation
- Enable TypeScript type checking without emitting compiled files
- Support generic typing for cache values

This implementation provides a lightweight caching solution suitable for scenarios requiring fast LRU behavior with minimal overhead.

> Created by **GitHub Ace** · [View Channel](https://ace.githubnext.com/lukeed/flru/01KEYY31M3QN8EHJW0MVV63NNA)